### PR TITLE
Use `pop-to-buffer` instead of `display-buffer` for metadata

### DIFF
--- a/nov.el
+++ b/nov.el
@@ -478,7 +478,7 @@ the HTML is rendered with `shr-render-region'."
               (insert (propertize "None" 'face 'italic)))
             (insert "\n")))
         (goto-char (point-min))))
-    (display-buffer buffer)))
+    (pop-to-buffer buffer)))
 
 (defun nov-next-chapter ()
   "Go to the next chapter and render its document."


### PR DESCRIPTION
`pop-to-buffer` selects the buffer. With a single window, this allows the user to easily bury the metadata buffer and get back to reading the eBook in the single window.