### PR TITLE
Not a UUID

### DIFF
--- a/nov.el
+++ b/nov.el
@@ -225,9 +225,9 @@ If PARSE-XML-P is t, return the contents as parsed by libxml."
     version))
 
 (defun nov-content-unique-identifier-name (content)
-  "Return the UUID name for CONTENT.
+  "Return the unique identifier name referenced in CONTENT.
 This is used in `nov-content-unique-identifier' to retrieve the
-UUID."
+the specific type of unique identifier."
   (let* ((node (esxml-query "package[unique-identifier]" content))
          (name (esxml-node-attribute 'unique-identifier node)))
     (when (not name)
@@ -235,7 +235,7 @@ UUID."
     name))
 
 (defun nov-content-unique-identifier (content)
-  "Return the UUID for CONTENT."
+  "Return the the unique identifier for CONTENT."
   (let* ((name (nov-content-unique-identifier-name content))
          (selector (format "package>metadata>identifier[id='%s']"
                            (regexp-quote name)))


### PR DESCRIPTION
* Changed the help strings referring to the unique identifier to
  remove references to UUIDs as that may lead to confusion.
* While the identifier must be unique and while UUIDs are often
  utlised for that purpose due to being easy to generate
  programmarically, it is not a requirement of the OPF standard that
  this identifier must be a UUID.
* The OPF standard only specifies that the package element use the
  unique-identifire attribute to reference the identifier in the
  metadata element.  In turn the metadata element utilises the
  dc:identifier attribute with the ID matching the previous reference
  and the unique string of whatever format is specified.  Additional
  information can be supplied in subsequent meta tags.
* Common identifier types used include, but are not limited to: ISBNs,
  ISSNs, domain name based strings, URL based strings, MD5 hash
  digests, SHA hash digests, UUIDs and assorted other codes, including
  arbitrary ones set by the creator (including those hard coded in by
  creation software).
* See also:
  http://www.idpf.org/epub/30/spec/epub30-publications.html#sec-opf-metadata-identifiers-uid
  http://dublincore.org/documents/dcmi-terms/#terms-identifier