### PR TITLE
Note about interference with global-whitespace-mode

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,6 +72,10 @@ To completely disable the variable pitch font, customize
 ``nov-variable-pitch`` to ``nil``.  Text will be displayed with the
 default face instead which should be using a monospace font.
 
+Note: If you use ``global-whitespace-mode``, you may have to 
+``(setq whitespace-global-modes '(not nov-mode))`` (see the help for that
+variable), otherwise the font may show as monospace.
+
 Text width
 ..........
 


### PR DESCRIPTION
Reproducible in emacs -Q if you eval this:
```
(package-initialize)
(setq whitespace-style '(face trailing))
(global-font-lock-mode t)
(global-whitespace-mode t)
```
then open an epub and `M-x nov-mode`, then eval the above again.