### PR TITLE
Add nov-search-forward and nov-search-backwards

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,7 @@ Features:
 - Basic navigation (jump to TOC, previous/next chapter)
 - Remembering and restoring the last read position
 - Jump to next chapter when scrolling beyond end
+- Search backward and forward
 - Renders EPUB2 (.ncx) and EPUB3 (<nav>) TOCs
 - Hyperlinks to internal and external targets
 - Supports textual and image documents


### PR DESCRIPTION
Hey! Thanks for `nov-mode`. As you've seen on the Emacs Reddit, this is potentially my first Elisp contribution so do provide guidance!

It adds `nov-search-forward` and `nov-search-backward`, both composed on a generic `nov--search-direction` that decides how it should move between pages and how it should search for the query based on the value of its direction parameter. I don't know if that's very lispy at all but thought I'd re-use the logic.